### PR TITLE
Update requirements.windows.cuda11_8.txt

### DIFF
--- a/requirements.windows.cuda11_8.txt
+++ b/requirements.windows.cuda11_8.txt
@@ -3,8 +3,7 @@
 numpy<2                         # Installing NumPy, a package for scientific computing
 
 # PaddlePaddle from PyPi is for CUDA 10.2 only. Need to use paddlepaddle.org for other CUDA versions
--i https://mirror.baidu.com/pypi/simple
-paddlepaddle-gpu==2.6.0         # Installing PaddlePaddle, Parallel Distributed Deep Learning
+paddlepaddle-gpu==2.6.2         # Installing PaddlePaddle, Parallel Distributed Deep Learning
 
 #paddleocr==2.6.1.3             # Installing PaddleOCR, the OCR toolkit based on PaddlePaddle
 paddleocr==2.7.0.3              # Installing PaddleOCR, the OCR toolkit based on PaddlePaddle

--- a/requirements.windows.cuda11_8.txt
+++ b/requirements.windows.cuda11_8.txt
@@ -2,7 +2,7 @@
 
 numpy<2                         # Installing NumPy, a package for scientific computing
 
-# PaddlePaddle from PyPi is for CUDA 10.2 only. Need to use paddlepaddle.org for other CUDA versions
+# PaddlePaddle from PyPi is for CUDA 11.8 only. Need to use paddlepaddle.org for other CUDA versions
 paddlepaddle-gpu==2.6.2         # Installing PaddlePaddle, Parallel Distributed Deep Learning
 
 #paddleocr==2.6.1.3             # Installing PaddleOCR, the OCR toolkit based on PaddlePaddle


### PR DESCRIPTION
Updated paddlepaddle-gpu

https://pypi.org/ paddlepaddle-gpu is for CUDA 11.8

![image](https://github.com/user-attachments/assets/382d041b-b633-47c5-a2d4-dce203e97bdc)
