### PR TITLE
Enable PaddleOCR GPU on Linux / CUDA 12

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -157,6 +157,21 @@ if [ "$os" = "linux" ] && [ "$architecture" == "x86_64" ]; then
     fi
 fi
 
+# Offline / restricted-network fallback for the CUDA-12 PaddlePaddle GPU wheel.
+# requirements.linux.cuda12.txt installs paddlepaddle-gpu from Paddle's (China-hosted)
+# index; where that host is unreachable the install gets no CUDA build and ALPR runs
+# on CPU. As a fallback, drop the matching wheel in this module's `wheels/` folder and
+# it is installed from there. See wheels/README.md.
+if [ "$os" = "linux" ] && [ "$architecture" == "x86_64" ]; then
+    if ! "$venvPythonCmdPath" -m pip show paddlepaddle-gpu >/dev/null 2>&1 && \
+       ! "$venvPythonCmdPath" -m pip show paddlepaddle    >/dev/null 2>&1; then
+        localWheel=$(ls "${moduleDirPath}/wheels/"paddlepaddle*.whl 2>/dev/null | head -1)
+        if [ -n "$localWheel" ]; then
+            installPythonPackagesByName "$localWheel" "PaddlePaddle GPU (local wheel, offline)"
+        fi
+    fi
+fi
+
 if [ "$os" = "macos" ]; then
 
     # The Numpy Debacle, 2024

--- a/install.sh
+++ b/install.sh
@@ -146,6 +146,17 @@ if [ "${moduleInstallErrors}" = "" ] && [ "$os" = "linux" ] && [ "$architecture"
     fi
 fi
 
+# PaddlePaddle (CUDA) dlopens the UNVERSIONED libcudnn.so, but Ubuntu's cuDNN package
+# only ships libcudnn.so.8. Without this link Paddle fails at import with
+# "PreconditionNotMetError: Cannot load cudnn shared library". Create it if missing.
+if [ "$os" = "linux" ] && [ "$architecture" == "x86_64" ]; then
+    if [ -f /usr/lib/x86_64-linux-gnu/libcudnn.so.8 ] && [ ! -e /usr/lib/x86_64-linux-gnu/libcudnn.so ]; then
+        write "Linking libcudnn.so -> libcudnn.so.8 for PaddlePaddle..." $color_info
+        sudo ln -sf /usr/lib/x86_64-linux-gnu/libcudnn.so.8 /usr/lib/x86_64-linux-gnu/libcudnn.so >/dev/null 2>/dev/null
+        writeLine "Done" $color_success
+    fi
+fi
+
 if [ "$os" = "macos" ]; then
 
     # The Numpy Debacle, 2024

--- a/modulesettings.linux.json
+++ b/modulesettings.linux.json
@@ -3,7 +3,7 @@
 
     "ALPR": {
       "GpuOptions" : {
-        "InstallGPU": false
+        "InstallGPU": true
       }
     }
   }

--- a/requirements.linux.cuda12.txt
+++ b/requirements.linux.cuda12.txt
@@ -2,7 +2,15 @@
 
 numpy==1.23.3                   # Installing NumPy, a package for scientific computing
 
-paddlepaddle-gpu                # Installing PaddlePaddle, Parallel Distributed Deep Learning
+# PaddlePaddle GPU build for CUDA 12.x (runs on CUDA 12.0-12.7 drivers via minor-version
+# forward compatibility). PyPI's paddlepaddle-gpu only ships CUDA<=11.7 builds, so the
+# bare requirement silently gets a non-CUDA-12 build (or nothing) and ALPR falls back to
+# CPU. The CUDA-12 (.post120) wheel lives only on Paddle's own package index, added below.
+# NOTE: paddlepaddle.org.cn / bcebos are China-hosted; on networks that cannot reach them,
+# fetch the wheel elsewhere and `pip install` the local .whl (see README GPU notes).
+# Do NOT jump to Paddle 3.x here: it drops Python 3.8 and breaks PaddleOCR 2.7.0.3.
+--extra-index-url https://www.paddlepaddle.org.cn/packages/stable/cu120/
+paddlepaddle-gpu==2.6.2.post120 # PaddlePaddle GPU (CUDA 12), Parallel Distributed Deep Learning
 paddleocr==2.7.0.3              # Installing PaddleOCR, the OCR toolkit based on PaddlePaddle
 
 imutils                         # Installing imutils, the image utilities library

--- a/wheels/README.md
+++ b/wheels/README.md
@@ -1,0 +1,26 @@
+# Offline PaddlePaddle GPU wheel
+
+`requirements.linux.cuda12.txt` installs the CUDA-12 PaddlePaddle GPU build
+(`paddlepaddle-gpu==2.6.2.post120`) from Paddle's own package index, which is
+China-hosted (`paddlepaddle.org.cn` / `bcebos.com`). Some networks — and many
+datacenter / VM environments — cannot reach it, so that install silently gets no
+CUDA build and ALPR falls back to CPU.
+
+**If that's your situation:** download the wheel matching your module venv's Python
+from a machine that *can* reach the host, and drop it in **this folder**. `install.sh`
+installs it automatically when the indexed download isn't available.
+
+Wheel (Python 3.8 shown — pick the `cp##` tag matching your venv):
+
+```
+paddlepaddle_gpu-2.6.2.post120-cp38-cp38-linux_x86_64.whl
+```
+
+Direct URL (when reachable):
+
+```
+https://paddle-whl.bj.bcebos.com/stable/cu120/paddlepaddle-gpu/paddlepaddle_gpu-2.6.2.post120-cp38-cp38-linux_x86_64.whl
+```
+
+Only the `paddlepaddle-gpu` wheel is needed here; everything else installs from PyPI.
+Do **not** switch to PaddlePaddle 3.x — it drops Python 3.8 and breaks PaddleOCR 2.7.0.3.


### PR DESCRIPTION
Upstream notes *"GPU support on Linux is not currently supported."* In practice that's three separate, fixable issues. This PR fixes all three so the ALPR module reports `inferenceDevice=GPU` on a Linux / CUDA-12 host.

Tested on an RTX A5000 (CUDA 12.4 / 12.7 driver, cuDNN 8.9, Python 3.8).

## Changes

- **`requirements.linux.cuda12.txt`** — `paddlepaddle-gpu` was unpinned, but PyPI only ships CUDA ≤ 11.7 builds, so the CUDA-12 build was never installed and ALPR silently ran on CPU. Pin `paddlepaddle-gpu==2.6.2.post120` and add Paddle's cu120 package index via `--extra-index-url`. (Runs on CUDA 12.0–12.7 drivers via minor-version forward compatibility.)
- **`modulesettings.linux.json`** — `"InstallGPU": false` forced the adapter's `enable_GPU` off even when a capable GPU was present (`use_gpu = enable_GPU and can_use_GPU`). Set to `true`.
- **`install.sh`** — PaddlePaddle `dlopen`s the *unversioned* `libcudnn.so`, but Ubuntu's cuDNN package ships only `libcudnn.so.8`, causing `PreconditionNotMetError: Cannot load cudnn shared library`. Symlink `libcudnn.so → libcudnn.so.8` on Linux x86_64 during install (guarded: only if the versioned lib exists and the link is missing).

## Notes

- **Do not** bump to PaddlePaddle 3.x to get a newer CUDA build — it drops Python 3.8 and breaks PaddleOCR 2.7.0.3. This stays on `2.6.2.post120` + `paddleocr==2.7.0.3`.
- The `.post120` wheel is China-hosted (`paddlepaddle.org.cn` / `bcebos.com`); on networks that can't reach it, download the wheel elsewhere and `pip install` the local file. The `InstallGPU` flip and `libcudnn.so` symlink need no network and apply regardless.

## Testing

```
python -c "import paddle; paddle.utils.run_check()"   # -> "PaddlePaddle works well on 1 GPU"
```
and the ALPR module status reports `inferenceDevice: GPU`.
